### PR TITLE
Add copy logic to build.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 jordancolburn.com
 _site
+site

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1,0 +1,26 @@
+import os
+import shutil
+from pathlib import Path
+
+SRC_DIRS = ['styles', 'assets', 'uploads']
+DEST_ROOT = Path('site')
+
+
+def copy_directory(src: Path, dest: Path):
+    """Copy directory recursively, overwriting existing contents."""
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(src, dest)
+
+
+def main():
+    DEST_ROOT.mkdir(parents=True, exist_ok=True)
+    for folder in SRC_DIRS:
+        src_path = Path(folder)
+        if src_path.exists() and src_path.is_dir():
+            dest_path = DEST_ROOT / folder
+            copy_directory(src_path, dest_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create `scripts` folder with new `build.py`
- copy assets into `site/` when building
- ignore the build output directory

## Testing
- `python3 scripts/build.py`

------
https://chatgpt.com/codex/tasks/task_e_68409aeade54832d995b483886a12e50