### PR TITLE
Enable GA4 analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ theme: minima
 plugins:
   - jekyll-feed
 
-google_analytics: UA-26600255-1
+google_analytics: G-ZLCSXT9Y49
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.

--- a/_includes/google-analytics.html
+++ b/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ site.google_analytics }}');
+</script>
+


### PR DESCRIPTION
## Summary
- switch to GA4 analytics key
- add GA4 analytics snippet

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d1b2f2e58832dac2eddc203b35a74